### PR TITLE
[refactor/#21] DnsSpoofingDetector 개선

### DIFF
--- a/app/src/main/java/com/example/allinsafe_spoofing/Ac5_02_spoofingdetect_process.kt
+++ b/app/src/main/java/com/example/allinsafe_spoofing/Ac5_02_spoofingdetect_process.kt
@@ -97,7 +97,7 @@ class Ac5_02_spoofingdetect_process : ComponentActivity() {
     fun detect_complete(binding:Ac502SpoofingdetectProcessBinding){
 
         //실제 스푸핑 코드와 연동하였을때 사용하기 위한 함수
-        //Toast.makeText(this.applicationContext,"스푸핑 탐지가 완료되었습니다!",Toast.LENGTH_LONG).show()
+        Toast.makeText(this.applicationContext,"스푸핑 탐지가 완료되었습니다!",Toast.LENGTH_LONG).show()
         var intent=Intent(this,Ac5_03_spoofoingdetect_completed::class.java)
         startActivity(intent)
     }

--- a/app/src/main/java/com/example/allinsafe_spoofing/detection/packettest/DummyPacketInjector.kt
+++ b/app/src/main/java/com/example/allinsafe_spoofing/detection/packettest/DummyPacketInjector.kt
@@ -1,6 +1,5 @@
 package com.example.allinsafe_spoofing.detection.packettest
 
-import android.util.Log
 import com.example.allinsafe_spoofing.detection.arpdetector.ArpData
 import com.example.allinsafe_spoofing.detection.arpdetector.ArpSpoofingDetector
 import com.example.allinsafe_spoofing.detection.common.LogManager
@@ -10,49 +9,46 @@ import java.nio.ByteBuffer
 object DummyPacketInjector {
 
     private const val TAG = "DummyPacketInjector"
-    private lateinit var dns_detector:DnsSpoofingDetector
-    private lateinit var arp_detector:ArpSpoofingDetector
-    fun dns_init(detector: DnsSpoofingDetector){
-        this.dns_detector=detector
+    private lateinit var dns_detector: DnsSpoofingDetector
+    private lateinit var arp_detector: ArpSpoofingDetector
+
+    fun dns_init(detector: DnsSpoofingDetector) {
+        this.dns_detector = detector
     }
-    fun arp_init(detector: ArpSpoofingDetector){
-        this.arp_detector=detector
+
+    fun arp_init(detector: ArpSpoofingDetector) {
+        this.arp_detector = detector
     }
-    // 🔹 DNS 더미 패킷 삽입
+
+    // 🔹 DNS 더미 패킷 삽입 (테스트용)
     fun injectDummyDnsPacket(detector: DnsSpoofingDetector) {
-        //Log.d(TAG, "🚀 테스트용 더미 DNS 패킷 삽입...")
         LogManager.log(TAG, "🚀 테스트용 더미 DNS 패킷 삽입...")
-        detector.pendingRequests[0] = "8.8.8.8"  // 테스트용 요청 IP
+        detector.addDummyRequest(0, "8.8.8.8")  // ✅ 변경: addDummyRequest 사용
 
         val dummyBuffer = ByteBuffer.allocate(60)
 
-        // IPv4 Header
-        dummyBuffer.put(0x45.toByte()) // Version + IHL
-        dummyBuffer.put(0)             // DSCP + ECN
-        dummyBuffer.putShort(60)       // Total Length
-        dummyBuffer.putShort(0)        // Identification
-        dummyBuffer.putShort(0)        // Flags + Fragment Offset
-        dummyBuffer.put(64.toByte())   // TTL
-        dummyBuffer.put(17.toByte())   // Protocol (UDP)
-        dummyBuffer.putShort(0)        // Header checksum
+        dummyBuffer.put(0x45.toByte())
+        dummyBuffer.put(0)
+        dummyBuffer.putShort(60)
+        dummyBuffer.putShort(0)
+        dummyBuffer.putShort(0)
+        dummyBuffer.put(64.toByte())
+        dummyBuffer.put(17.toByte())
+        dummyBuffer.putShort(0)
 
-        // Source IP: 192.168.1.100
         dummyBuffer.put(byteArrayOf(192.toByte(), 168.toByte(), 1.toByte(), 100.toByte()))
-        // Destination IP: 10.0.0.1
         dummyBuffer.put(byteArrayOf(10.toByte(), 0.toByte(), 0.toByte(), 1.toByte()))
 
-        // UDP Header
-        dummyBuffer.putShort(53)       // Source Port
-        dummyBuffer.putShort(5353)     // Destination Port
-        dummyBuffer.putShort(20)       // Length
-        dummyBuffer.putShort(0)        // Checksum
+        dummyBuffer.putShort(53)
+        dummyBuffer.putShort(5353)
+        dummyBuffer.putShort(20)
+        dummyBuffer.putShort(0)
 
-        // DNS Header (간단한 응답 형태)
-        dummyBuffer.putShort(0.toShort())         // Transaction ID
-        dummyBuffer.putShort(0x8180.toShort())    // Flags
+        dummyBuffer.putShort(0.toShort())
+        dummyBuffer.putShort(0x8180.toShort())
 
         dummyBuffer.position(8)
-        dummyBuffer.put(5.toByte()) // 임의 위치 조정 (포맷 유효하지 않을 수 있음 - 테스트 용도)
+        dummyBuffer.put(5.toByte())
 
         dummyBuffer.rewind()
         detector.processPacket(dummyBuffer)
@@ -60,7 +56,6 @@ object DummyPacketInjector {
 
     // 🔹 ARP 더미 패킷 삽입
     fun injectDummyArpData(detector: ArpSpoofingDetector) {
-        //Log.d(TAG, "🧪 테스트용 더미 ARP 데이터 삽입...")
         LogManager.log(TAG, "🧪 테스트용 더미 ARP 데이터 삽입...")
 
         val dummyArp = ArpData(
@@ -72,49 +67,44 @@ object DummyPacketInjector {
         detector.analyzePacket(dummyArp)
     }
 
-    //🔹 DNS 더미 패킷 삽입-detector없는 버전
+    // 🔹 DNS 더미 패킷 삽입 (dns_detector 사용)
     fun injectDummyDnsPacket() {
-        //Log.d(TAG, "🚀 테스트용 더미 DNS 패킷 삽입...")
         LogManager.log(TAG, "🚀 테스트용 더미 DNS 패킷 삽입...")
-        dns_detector.pendingRequests[0] = "8.8.8.8"  // 테스트용 요청 IP
+        dns_detector.addDummyRequest(0, "8.8.8.8")  // ✅ 변경: addDummyRequest 사용
 
         val dummyBuffer = ByteBuffer.allocate(60)
 
-        // IPv4 Header
-        dummyBuffer.put(0x45.toByte()) // Version + IHL
-        dummyBuffer.put(0)             // DSCP + ECN
-        dummyBuffer.putShort(60)       // Total Length
-        dummyBuffer.putShort(0)        // Identification
-        dummyBuffer.putShort(0)        // Flags + Fragment Offset
-        dummyBuffer.put(64.toByte())   // TTL
-        dummyBuffer.put(17.toByte())   // Protocol (UDP)
-        dummyBuffer.putShort(0)        // Header checksum
+        dummyBuffer.put(0x45.toByte())
+        dummyBuffer.put(0)
+        dummyBuffer.putShort(60)
+        dummyBuffer.putShort(0)
+        dummyBuffer.putShort(0)
+        dummyBuffer.put(64.toByte())
+        dummyBuffer.put(17.toByte())
+        dummyBuffer.putShort(0)
 
-        // Source IP: 192.168.1.100
         dummyBuffer.put(byteArrayOf(192.toByte(), 168.toByte(), 1.toByte(), 100.toByte()))
-        // Destination IP: 10.0.0.1
         dummyBuffer.put(byteArrayOf(10.toByte(), 0.toByte(), 0.toByte(), 1.toByte()))
 
-        // UDP Header
-        dummyBuffer.putShort(53)       // Source Port
-        dummyBuffer.putShort(5353)     // Destination Port
-        dummyBuffer.putShort(20)       // Length
-        dummyBuffer.putShort(0)        // Checksum
+        dummyBuffer.putShort(53)
+        dummyBuffer.putShort(5353)
+        dummyBuffer.putShort(20)
+        dummyBuffer.putShort(0)
 
-        // DNS Header (간단한 응답 형태)
-        dummyBuffer.putShort(0.toShort())         // Transaction ID
-        dummyBuffer.putShort(0x8180.toShort())    // Flags
+        dummyBuffer.putShort(0.toShort())
+        dummyBuffer.putShort(0x8180.toShort())
 
         dummyBuffer.position(8)
-        dummyBuffer.put(5.toByte()) // 임의 위치 조정 (포맷 유효하지 않을 수 있음 - 테스트 용도)
+        dummyBuffer.put(5.toByte())
 
         dummyBuffer.rewind()
         dns_detector.processPacket(dummyBuffer)
     }
-    // 🔹 ARP 더미 패킷 삽입-detector없는 버전
+
+    // 🔹 ARP 더미 패킷 삽입 (arp_detector 사용)
     fun injectDummyArpData() {
-        //Log.d(TAG, "🧪 테스트용 더미 ARP 데이터 삽입...")
         LogManager.log(TAG, "🚀 테스트용 더미 ARP 패킷 삽입...")
+
         val dummyArp = ArpData(
             senderIp = "192.168.78.1",
             senderMac = "00-11-22-33-44-66",
@@ -123,5 +113,4 @@ object DummyPacketInjector {
         )
         arp_detector.analyzePacket(dummyArp)
     }
-}//
-
+}


### PR DESCRIPTION
# [refactor#21] DnsSpoofingDetector 개선

## 🔘Part

- [x] 스푸핑

  <br/>

## 🔎 작업 내용

- reponse 패킷, 즉 외부 서버에서 기기로 들어오는 Inbound 트래픽은 시스템 프로세스에서 소모되어 VPN까지 넘어오지 않기에 로그로 뜨지 않음

- 테스트용 addDummyRequest() public 메서드를 추가하여 테스트 코드에서만 삽입 가능하도록 개선
- DNS Request 중복 TXID 기록 방지 기능 추가

  <br/>

## 🖼️ 이미지 첨부

![image](https://github.com/user-attachments/assets/61fa6d9b-c325-44f5-9514-5fc70f6de761)

<br/>

## 🔧 앞으로의 과제

- 몇초간만 탐지되도록 로직 개선

  <br/>

## ➕ 이슈 링크

- https://github.com/Team-AllInSafe/allinsafe-spoofing/issues/21

<br/>
